### PR TITLE
Some changes due to personal preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 omega.hpp is a tiny, C++14 meta-library to manipulate tuple at compile time.
 
 ### Examples
+All examples are contained in the *driver.cpp* file
 
 #### 1. first example
 ```cpp
@@ -98,4 +99,4 @@ int main()
 
 ### How to compile
 
-g++ -O3 -std=c++1y ex.cpp -o ex
+g++ -O3 -std=c++1y driver.cpp -o ex

--- a/driver.cpp
+++ b/driver.cpp
@@ -1,0 +1,85 @@
+#include "omega.hpp"
+
+#include <iostream>
+#include <tuple>
+
+//TODO: MAKE THIS BECOME A TEST
+namespace
+{
+    void print(int a, int b, const std::string& n)
+    {
+        std::cout << "a = " << a << ", b = " << b << ", n = " << n << std::endl;
+    }
+
+    void first_example()
+    {
+        // create a tuple
+        const auto t = std::make_tuple(5, 6, 7, "yuppi!", 8, 9, 10.5);
+
+        // create another tuple based on t, using a list from 1 to 3 ([1,2,3])
+        auto t2 = omega::make_list<1, 3>(t); // decltype(t2) = std::tuple<int, int, const char*>
+
+        // use t2 as usual
+        std::cout << std::get<0>(t2) << std::endl; // out: 6
+        omega::invoke(print, t2); // out: a = 6, b = 7, n = yuppi!
+
+        // reverse list are also supported: just reverse the indexes
+        auto t4 = omega::make_list<5, 1>(t); // decltype(t4) = std::tuple<int, int, const char*, int, int>
+
+        // or keep using a dedicated API which just forwards to the underlying
+        // common implementation
+        auto t5 = omega::make_reverse_list<5, 1>(t); // decltype(t4) = std::tuple<int, int, const char*, int, int>
+
+        std::cout << std::get<2>(t4) << std::endl; // out: yuppi!
+        std::cout << std::get<2>(t5) << std::endl; // out: yuppi!
+
+        // or we can use index : omega::make_index_list
+        auto t3 = omega::make_index_list<3, 2, 1, 6>(t); // decltype(t3) = std::tuple<const char*, int, int, double>
+        std::cout << std::get<3>(t3) << std::endl; // out: 10.5
+
+        omega::invoke(print, omega::make_index_list<2, 5, 3>(t)); // out: a = 7, b = 9, n = yuppi!
+    }
+
+    void head_tail()
+    {
+        const auto t = std::make_tuple(5, 6, 7, "yuppi!", 8, 9, 10.5);
+        std::cout << "t = " << t << std::endl; // out: t = <5, 6, 7, yuppi!, 8, 9, 10.5>
+
+        auto t1 = omega::tail(t);
+        std::cout << "tail(t) = " << t1 << std::endl; // out: tail(t) = <6, 7, yuppi!, 8, 9, 10.5>
+
+        auto t2 = omega::head(t);
+        std::cout << "head(t) = " << t2 << std::endl; // out: head(t) = <5>
+    }
+
+    void init_last_reverse()
+    {
+        const auto t = omega::reverse(std::make_tuple("hello", 3.14, 42));
+        std::cout << "t = " << t << std::endl; // out: t = <42, 3.14, hello>
+
+        const auto t1 = omega::last(t);
+        std::cout << "last(t) = " << t1 << std::endl; // out: last(t) = <hello>
+
+        const auto t2 = omega::init(t);
+        std::cout << "init(t) = " << t2 << std::endl; // out: init(t) = <42, 3.14>
+    }
+
+    void take_drop()
+    {
+        const auto t = std::make_tuple(42, "wood", 5.1, "world!");
+        const auto t1 = omega::drop<1>(t);
+        std::cout << "drop<1>(t) = " << t1 << std::endl; // out: drop<1>(t) = <wood, 5.1, world!>
+
+        const auto t2 = omega::take<3>(t);
+        std::cout << "take<3>(t) = " << t2 << std::endl; // out: take<3>(t) = <42, wood, 5.1>
+    }
+}//unnamed namespace
+
+int main()
+{
+    first_example();
+    head_tail();
+    init_last_reverse();
+    take_drop();
+}
+

--- a/omega.hpp
+++ b/omega.hpp
@@ -18,6 +18,8 @@ namespace omega
         template <int B, int E>
             using _same_index = std::is_same<_int_c<B>, _int_c<E>>;
 
+        template <typename Tup>
+            constexpr size_t _tuple_size = std::tuple_size<typename std::remove_reference<Tup>::type>::value;
 
         /* make_list implementation */
 
@@ -147,7 +149,7 @@ namespace omega
 	template <class Tup>
 	decltype(auto) tail(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(S > 1, "");
 
 		return make_list<1, S-1>(tup);
@@ -162,7 +164,7 @@ namespace omega
 	template <class Tup>
 	decltype(auto) head(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(S > 0, "");
 		return make_index_list<0>(tup);
 	}
@@ -170,7 +172,7 @@ namespace omega
 	template <class Tup>
 	decltype(auto) last(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(S > 0, "");
 		return make_index_list<S-1>(tup);
 	}
@@ -178,7 +180,7 @@ namespace omega
 	template <class Tup>
 	decltype(auto) reverse(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(S > 0, "");
 		return make_reverse_list<S-1, 0>(tup);
 	}
@@ -201,7 +203,7 @@ namespace omega
 	template <int N, class Tup>
 	decltype(auto) drop(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(N <= S && S > 0, "");
 
 		return make_list<N, S-1>(tup);
@@ -210,7 +212,7 @@ namespace omega
 	template <int N, class Tup>
 	decltype(auto) take(Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		static_assert(N >= 0 && N <= S && S > 0, "");
 
 		return make_list<0, N-1>(tup);
@@ -222,7 +224,7 @@ namespace omega
 	template<typename Func, typename Tup>
 	decltype(auto) invoke(Func&& func, Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		return detail::_invoke(std::forward<Func>(func),
 							 std::forward<Tup>(tup),
 							 std::make_index_sequence<S>{});
@@ -242,7 +244,7 @@ namespace omega
 	template <typename Tup>
 	void show(std::ostream& out, Tup&& tup)
 	{
-		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
+		constexpr auto S = detail::_tuple_size<Tup>;
 		out << "<";
         detail::_show<0, S-1>(out, std::forward<Tup>(tup), detail::_same_index<0, S-1>{});
 		out << ">";

--- a/omega.hpp
+++ b/omega.hpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <utility>
 #include <type_traits>
+#include <iostream>
 
 
 namespace omega

--- a/omega.hpp
+++ b/omega.hpp
@@ -10,91 +10,135 @@
 
 namespace omega
 {
-	template <int i>
-	using int_c = std::integral_constant<int, i>;
+    namespace detail
+    {
+        template <int i>
+            using _int_c = std::integral_constant<int, i>;
 
-	/* make_list */
+        template <int B, int E>
+            using _same_index = std::is_same<_int_c<B>, _int_c<E>>;
 
-	template <int B, int E, typename Tup>
-	decltype(auto) _make_list(Tup&& tup, std::true_type)
-	{
-		return std::make_tuple(std::get<B>(std::forward<Tup>(tup)));
-	}
 
-	template <int B, int E, typename Tup>
-	decltype(auto) _make_list(Tup&& tup, std::false_type)
-	{
-		return std::tuple_cat(
-			std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
-			_make_list<B+1, E>(std::forward<Tup>(tup), std::is_same<int_c<B+1>, int_c<E>>{})
-		);
-	}
+        /* make_list implementation */
 
-	template <int B, int E, typename Tup>
-	decltype(auto) _check_bound(Tup&& tup, std::true_type)
-	{
-		return _make_list<B, E>(std::forward<Tup>(tup), std::is_same<int_c<B>, int_c<E>>{});
-	}
+        template <int B, int E, typename Tup>
+            decltype(auto) _make_list(Tup&& tup, std::true_type)
+            {
+                return std::make_tuple(std::get<B>(std::forward<Tup>(tup)));
+            }
 
-	template <int B, int E, typename Tup>
-	decltype(auto) _check_bound(Tup&&, std::false_type)
-	{
-		return std::make_tuple();
-	}
+        template <int B, int E, typename Tup>
+            decltype(auto) _make_list(Tup&& tup, std::false_type)
+            {
+                return std::tuple_cat(
+                    std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
+                    _make_list<B+1, E>(std::forward<Tup>(tup), _same_index<B+1, E>{})
+                    );
+            }
 
+        template <int B, int E, typename Tup>
+            decltype(auto) _check_bound(Tup&& tup, std::true_type)
+            {
+                return _make_list<B, E>(std::forward<Tup>(tup), _same_index<B, E>{});
+            }
+
+        template <int B, int E, typename Tup>
+            decltype(auto) _check_bound(Tup&&, std::false_type)
+            {
+                return std::make_tuple();
+            }
+
+        /* make_reverse_list implementation */
+
+        template <int B, int E, typename Tup>
+            decltype(auto) _make_reverse_list(Tup&& tup, std::true_type)
+            {
+                return std::make_tuple(std::get<B>(std::forward<Tup>(tup)));
+            }
+
+        template <int B, int E, typename Tup>
+            decltype(auto) _make_reverse_list(Tup&& tup, std::false_type)
+            {
+                return std::tuple_cat(
+                    std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
+                    _make_reverse_list<B-1, E>(std::forward<Tup>(tup), _same_index<B-1, E>{})
+                    );
+            }
+
+        /* make_index_list implementation */
+
+        template <class Tup>
+            decltype(auto) _make_index_list(Tup&&)
+            {
+                return std::make_tuple();
+            }
+
+        template <class Tup, int B, int ...Index>
+            decltype(auto) _make_index_list(Tup&& tup)
+            {
+                return std::tuple_cat(
+                    std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
+                    _make_index_list<Tup, Index...>(std::forward<Tup>(tup))
+                    );
+            }
+
+
+        /* invoke function implementation */
+
+        template<typename Func, typename Tup, std::size_t... index>
+            decltype(auto) _invoke (Func&& func, Tup&& tup, std::index_sequence<index...>)
+            {
+                return func(std::get<index>(std::forward<Tup>(tup))...);
+            }
+
+        /* utility implementation */
+
+        template<typename Array, std::size_t... I>
+            decltype(auto) _array2tuple(const Array& a, std::index_sequence<I...>)
+            {
+                return std::make_tuple(a[I]...);
+            }
+
+        /* show tuple implementation */
+
+        template <int B, int E, typename Tup>
+            void _show(std::ostream& out, Tup&& tup, std::true_type)
+            {
+                out << std::get<B>(std::forward<Tup>(tup));
+            }
+
+        template <int B, int E, typename Tup>
+            void _show(std::ostream& out, Tup&& tup, std::false_type)
+            {
+                out << std::get<B>(std::forward<Tup>(tup)) << ", ";
+                _show<B+1, E>(out, std::forward<Tup>(tup), _same_index<B+1, E>{});
+            }
+
+
+    }//namespace detail
+
+
+    /* make_list */
 	template <int B, int E, typename Tup>
 	decltype(auto) make_list(Tup&& tup)
 	{
-		return _check_bound<B, E>(tup, std::integral_constant<bool, B <= E>{});
-	}
-
-
-	/* make_reverse_list */
-
-	template <int B, int E, typename Tup>
-	decltype(auto) _make_reverse_list(Tup&& tup, std::true_type)
-	{
-		return std::make_tuple(std::get<B>(std::forward<Tup>(tup)));
-	}
-
-	template <int B, int E, typename Tup>
-	decltype(auto) _make_reverse_list(Tup&& tup, std::false_type)
-	{
-		return std::tuple_cat(
-			std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
-			_make_reverse_list<B-1, E>(std::forward<Tup>(tup), std::is_same<int_c<B-1>, int_c<E>>{})
-		);
+		return detail::_check_bound<B, E>(tup, std::integral_constant<bool, B <= E>{});
 	}
 
 	template <int B, int E, typename Tup>
 	decltype(auto) make_reverse_list(Tup&& tup)
 	{
 		static_assert(B >= E, "");
-		return _make_reverse_list<B, E>(std::forward<Tup>(tup), std::is_same<int_c<B>, int_c<E>>{});
+		return detail::_make_reverse_list<B, E>(std::forward<Tup>(tup), detail::_same_index<B, E>{});
 	}
 
 
 	/* make_index_list */
 
-	template <class Tup>
-	decltype(auto) _make_index_list(Tup&& tup)
-	{
-		return std::make_tuple();
-	}
-
-	template <class Tup, int B, int ...Index>
-	decltype(auto) _make_index_list(Tup&& tup)
-	{
-		return std::tuple_cat(
-			std::make_tuple(std::get<B>(std::forward<Tup>(tup))),
-			_make_index_list<Tup, Index...>(std::forward<Tup>(tup))
-		);
-	}
-
 	template <int B, int ...Index, class Tup>
 	decltype(auto) make_index_list(Tup&& tup)
 	{
-		return _make_index_list<Tup, B, Index...>(std::forward<Tup>(tup));
+		return detail::_make_index_list<Tup, B, Index...>(std::forward<Tup>(tup));
 	}
 
 
@@ -106,7 +150,7 @@ namespace omega
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(S > 1, "");
 
-		return omega::make_list<1, S-1>(tup);
+		return make_list<1, S-1>(tup);
 	}
 
 	template <class T>
@@ -120,7 +164,7 @@ namespace omega
 	{
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(S > 0, "");
-		return omega::make_index_list<0>(tup);
+		return make_index_list<0>(tup);
 	}
 
 	template <class Tup>
@@ -128,7 +172,7 @@ namespace omega
 	{
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(S > 0, "");
-		return omega::make_index_list<S-1>(tup);
+		return make_index_list<S-1>(tup);
 	}
 
 	template <class Tup>
@@ -136,7 +180,7 @@ namespace omega
 	{
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(S > 0, "");
-		return omega::make_reverse_list<S-1, 0>(tup);
+		return make_reverse_list<S-1, 0>(tup);
 	}
 
 	decltype(auto) reverse(std::tuple<>)
@@ -160,7 +204,7 @@ namespace omega
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(N <= S && S > 0, "");
 
-		return omega::make_list<N, S-1>(tup);
+		return make_list<N, S-1>(tup);
 	}
 
 	template <int N, class Tup>
@@ -169,23 +213,17 @@ namespace omega
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		static_assert(N >= 0 && N <= S && S > 0, "");
 
-		return omega::make_list<0, N-1>(tup);
+		return make_list<0, N-1>(tup);
 	}
 
 
 	/* invoke function */
 
-	template<typename Func, typename Tup, std::size_t... index>
-	decltype(auto) invoke_helper(Func&& func, Tup&& tup, std::index_sequence<index...>)
-	{
-		return func(std::get<index>(std::forward<Tup>(tup))...);
-	}
-
 	template<typename Func, typename Tup>
 	decltype(auto) invoke(Func&& func, Tup&& tup)
 	{
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
-		return invoke_helper(std::forward<Func>(func),
+		return detail::_invoke(std::forward<Func>(func),
 							 std::forward<Tup>(tup),
 							 std::make_index_sequence<S>{});
 	}
@@ -193,40 +231,20 @@ namespace omega
 
 	/* utility */
 
-	template<typename Array, std::size_t... I>
-	decltype(auto) a2t_impl(const Array& a, std::index_sequence<I...>)
-	{
-		return std::make_tuple(a[I]...);
-	}
-
 	template<typename T, std::size_t N, typename Indices = std::make_index_sequence<N>>
 	decltype(auto) array2tuple(const std::array<T, N>& a)
 	{
-		return a2t_impl(a, Indices());
+		return detail::_array2tuple(a, Indices());
 	}
 
-
-	// show tuple
-
-	template <int B, int E, typename Tup>
-	void _show(std::ostream& out, Tup&& tup, std::true_type)
-	{
-		out << std::get<B>(std::forward<Tup>(tup));
-	}
-
-	template <int B, int E, typename Tup>
-	void _show(std::ostream& out, Tup&& tup, std::false_type)
-	{
-		out << std::get<B>(std::forward<Tup>(tup)) << ", ";
-		_show<B+1, E>(out, std::forward<Tup>(tup), std::is_same<int_c<B+1>, int_c<E>>{});
-	}
+    /* show tuple */
 
 	template <typename Tup>
 	void show(std::ostream& out, Tup&& tup)
 	{
 		constexpr auto S = std::tuple_size<typename std::decay<Tup>::type>::value;
 		out << "<";
-		_show<0, S-1>(out, std::forward<Tup>(tup), std::is_same<int_c<0>, int_c<S-1>>{});
+        detail::_show<0, S-1>(out, std::forward<Tup>(tup), detail::_same_index<0, S-1>{});
 		out << ">";
 	}
 


### PR DESCRIPTION
The first 3 commits are mostly aesthetics: encapsulating what is considered "implementation" in a "detail" namespace
The 4th commit, marked "MAJOR" is, well, major...
I prefer to let the compiler do what you used to do via tag-dispatching on std::integral_constant (std::true_type, std::false_type) using class template specialization.
This is a matter of preference, I'm not sure what impacts it has on compile-time, but it also (I think) make things clearer as it allows you to expose a more unified interface for forward/backward index ranges and remove the need for a lot of checks on indexes

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/meox/omega.hpp/1)

<!-- Reviewable:end -->
